### PR TITLE
add possibility for subgalleries

### DIFF
--- a/archetypes/group.md
+++ b/archetypes/group.md
@@ -1,0 +1,8 @@
+---
+title: "{{ replace .Name "-" " " | title }}"
+date: {{ .Date }}
+albumthumb: ""
+type: "group"
+draft: true
+---
+

--- a/layouts/_default/group/section.html
+++ b/layouts/_default/group/section.html
@@ -9,7 +9,7 @@
 
     {{- /* Build the list of sections and thumbnails */}}
     {{- $.Scratch.Set "sections" (slice) }}
-    {{- range .Site.Sections.ByDate }}
+    {{- range .Page.Pages.ByDate }}
         {{- $title := .Title }}
         {{- $link := .Permalink }}
 
@@ -82,7 +82,7 @@
 
         {{- $.Scratch.Set $st_height_name (add ($.Scratch.Get $st_height_name) $elem_val.thumb.Height) }}
     {{- end }}
-
+    <div id="debug" />
     <div id="main">
         <div class="flexrow">
 
@@ -90,7 +90,6 @@
         {{- range $column_ind := seq $column_count }}
             {{- $st_name := printf "col-%d" $column_ind }}
             {{- $column := $.Scratch.Get $st_name }}
-
             <div class="flexcol">
             {{- range $column }}
                 <article class="thumb">

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,13 +1,26 @@
 <header id="header">
     {{ $url := .RelPermalink }}
     <h1>
-    <a href="{{ .Site.BaseURL }}"><strong>{{ .Site.Title }}</strong></a>
-    {{ range $index, $element := split $url "/" }}
-        {{ if ne $element "" }}
-            / {{ . | humanize }}
-        {{ end }}
+
+    {{ $url = (trim $url "/") }}
+    {{ $words := (split $url "/") }}
+    {{ $elems := (len $words) }}
+    {{ if gt $elems 1 }}
+        {{ $path := first (sub $elems 1) $words }}
+        {{ $path = delimit $path "/" }}
+
+        <a href="{{ .Site.BaseURL }}"><strong>{{ .Site.Title }}</strong></a>
+        <a href="{{ .Site.BaseURL }}{{ $path }}"><strong> / {{ $path | humanize }}</strong></a>
+        / {{ index $words (sub $elems 1) }}
+    {{ else }}
+        <a href="{{ .Site.BaseURL }}"><strong>{{ .Site.Title }}</strong></a>
+        {{ range $index, $element := split $url "/" }}
+            {{ if ne $element "" }}
+                / {{ . | humanize }}
+            {{ end }}
+        {{ end }}        
     {{ end }}
+
     </h1>
     {{ partial "navigation.html" . }}
-
 </header>


### PR DESCRIPTION
Hi, I really liked `autophugo`, but needed to have sub galleries. That's why I've made following changes:
* add section `group` type which functions like the `list.html` template used for the home page, but indexes only its own sub galleries
* modify `list.html` to display only root level sections
* add `group` archetype
* modify header to handle the url for the group gallery when you're in inner most gallery (currently working only for 1 level subgallery)

The changes don't break previous functionality at least from what I've tested.
It's working pretty neatly, you can see it in my photo gallery [tfl0pz.com](https://tfl0pz.com) currently only the Peru gallery is taking advantage of it.

Cheers!
