### PR TITLE
use relative link to albums

### DIFF
--- a/layouts/partials/sect_and_img_content.html
+++ b/layouts/partials/sect_and_img_content.html
@@ -15,7 +15,7 @@
     {{- $.Scratch.Set "sections" (slice) }}
     {{- range .Sections.ByDate }}
         {{- $title := .Title }}
-        {{- $link := .Permalink }}
+        {{- $link := .RelPermalink }}
 
         {{- /* The path we need under the assets directory */}}
         {{- $imgpath := path.Join .Params.albumthumb }}


### PR DESCRIPTION
Links from the main page to the albums are using fully qualified links.  This means if the site is ever accessed via a non-canonical url (say for testing a non-prod netlify deploy) the links will point at the canonical album and not the album from the alternate host.

This change makes the links relative so accessing an album will never result in a change in host.

I can't think of any case where it would be expected for an album to be on a different host.