### PR TITLE
Default phototitle to filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The `exampleSite` demonstrates the features unique to this theme.  In your site 
 * `full_quality` - display-sized image encoding quality after resizing (default 90%)
 * `column_count` - the number of columns in which to display images (default 2)
 * `breadcrumb_use_title` - if true, breadcrumbs (the path-like display at the bottom) will use page titles instead of paths
+* `filename_as_phototitle` - if true, a humanized form of the filename will be used as the phototitle (default false)
 
 Additionally, `Author.name` and `Author.email` in the site config will display as the author and webmaster email.
 

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -22,6 +22,7 @@ disableKinds = ["taxonomy", "taxonomyTerm"]
     #full_quality = 90
     #column_count = 2
     #breadcrumb_use_title = false
+    #filename_as_phototitle = false
     
     # Headerbar links
     # Do not put too many links here,

--- a/exampleSiteNoAlbum/config.toml
+++ b/exampleSiteNoAlbum/config.toml
@@ -21,6 +21,7 @@ disableKinds = ["taxonomy", "taxonomyTerm"]
     #full_width = 960
     #full_quality = 90
     #column_count = 2
+    #filename_as_phototitle = false
     
     # Headerbar links
     # Do not put here too many links,

--- a/layouts/partials/sect_and_img_content.html
+++ b/layouts/partials/sect_and_img_content.html
@@ -61,7 +61,7 @@
         {{- /* Build some scratch for upcoming search... */}}
         {{- $img_dat := newScratch }}
         {{- $img_dat.Set "alt" "" }}
-        {{- $img_dat.Set "phototitle" "" }}
+        {{- $img_dat.Set "phototitle" (humanize (replace (path.Base $elem_val.Name) (path.Ext $elem_val.Name) "")) }}
         {{- $img_dat.Set "description" "" }}
 
         {{- /* Search the resources for a matching image src, save off details */}}

--- a/layouts/partials/sect_and_img_content.html
+++ b/layouts/partials/sect_and_img_content.html
@@ -7,6 +7,7 @@
     {{- $full_width := default 960 ($.Param "full_width") }}
     {{- $thumb_quality := default 50 ($.Param "thumb_quality") }}
     {{- $full_quality := default 90 ($.Param "full_quality") }}
+    {{- $filename_as_phototitle := default false ($.Param "filename_as_phototitle") }}
 
     {{- $thumb_size := printf "%dx q%d" $thumb_width $thumb_quality }}
     {{- $full_size := printf "%dx q%d" $full_width $full_quality }}
@@ -61,7 +62,11 @@
         {{- /* Build some scratch for upcoming search... */}}
         {{- $img_dat := newScratch }}
         {{- $img_dat.Set "alt" "" }}
-        {{- $img_dat.Set "phototitle" (humanize (replace (path.Base $elem_val.Name) (path.Ext $elem_val.Name) "")) }}
+	{{- if $filename_as_phototitle }}
+		{{- $img_dat.Set "phototitle" (humanize (replace (path.Base $elem_val.Name) (path.Ext $elem_val.Name) "")) }}
+	{{- else }}
+		{{- $img_dat.Set "phototitle" "" }}
+	{{- end }}
         {{- $img_dat.Set "description" "" }}
 
         {{- /* Search the resources for a matching image src, save off details */}}


### PR DESCRIPTION
Adds a new theme config `filename_as_phototitle` which will use a humanized form of the filename as the photo title when enabled.  Defaults off to avoid any breaking changes.

This change makes it easy for me to drop photos in a folder and not need to edit the resources in the index file in most cases.