### PR TITLE
use filename hash, not index, to reference images in detail view

### DIFF
--- a/layouts/partials/sect_and_img_content.html
+++ b/layouts/partials/sect_and_img_content.html
@@ -142,7 +142,7 @@
         {{- $column := $.Scratch.Get $st_name }}
         <div class="flexcol">
         {{- range $column }}
-
+            {{- $filename := path.Base .image.Name }}
             <article class="thumb">
                 {{- if (eq .type "sect") }}
                     <a href="{{ .link }}" class="link" tabindex="0"><img src="{{ .thumb.RelPermalink }}" alt="{{ .title }}" /></a>
@@ -151,9 +151,9 @@
                     <a class="gallery-item" phototitle="{{ .phototitle }}"
                             description="{{ .description }}"
                             gallery_index="{{ .index }}"
-                            id="image_number_{{ .index }}"
+                            id="{{ md5 $filename }}"
                             downloadable="{{ cond $downloadable "true" "false" }}"
-                            orig_name="{{ path.Base .image.Name }}"
+                            orig_name="{{ $filename }}"
                             href="{{ .full.RelPermalink }}">
                         <img src="{{ .thumb.RelPermalink }}"
                             {{ with .alt }} alt="{{ . }}"{{ end }}>


### PR DESCRIPTION
The aim of this change list is to move away from using the position as image identifier in favor of the filename. This is based on the assumption that an author is less likely to rename a previously published file than they are to add another image to the collection. 

I initially tried to use the url escaped filename directly but ran into problems with the javascript click_hash function whenever my filenames contained spaces or other symbols. In the end, I actually like the md5 hash better as it is not only safer but also less distracting.

In general, I consider this change to be universally useful, therefore I did not offer a feature flag to toggle.  Of course, it would be easy to add one if desired. 
