### PR TITLE
Allow to overwrite resize logic to support restriction by height (mak…

### DIFF
--- a/layouts/partials/sect_and_img_content.html
+++ b/layouts/partials/sect_and_img_content.html
@@ -10,8 +10,19 @@
     {{- $filename_as_phototitle := default false ($.Param "filename_as_phototitle") }}
     {{- $downloadable := default true ($.Param "images_downloadable") }}
 
-    {{- $thumb_size := printf "%dx q%d" $thumb_width $thumb_quality }}
-    {{- $full_size := printf "%dx q%d" $full_width $full_quality }}
+    {{- /* Calculate thumb_size string from params unless a finished string is provided in the config. */}}
+    {{- $.Scratch.Set "thumb_size" (default "" ($.Param "thumb_size")) }}
+    {{ if  (eq  ($.Scratch.Get "thumb_size") "") }}
+        {{- $.Scratch.Set "thumb_size" (printf "%dx q%d" $thumb_width $thumb_quality) }}
+    {{ end }}
+    {{- $thumb_size := $.Scratch.Get "thumb_size" }}
+
+    {{- /* Same for full_size string */}}
+    {{- $.Scratch.Set "full_size" (default "" ($.Param "full_size")) }}
+    {{ if  (eq  ($.Scratch.Get "full_size") "") }}
+        {{- $.Scratch.Set "full_size" (printf "%dx q%d" $full_width $full_quality) }}
+    {{ end }}
+    {{- $full_size := $.Scratch.Get "full_size" }}
 
     {{- /* Build the list of sections and thumbnails */}}
     {{- $.Scratch.Set "sections" (slice) }}


### PR DESCRIPTION
This RP is a bit strange. Since I am moving my fork back towards an optional row-based layout in the long run, it really makes more sense for me to restrict images by height rather than by width. However, I don't want to add more noise to the config files, since I assume most people will go for the default. 

As a compromise, this change adds a "hidden feature:": IF an explicit and hopefully valid thumb_size string is specified, thumb_width and thumb_quality will be silently ignored. Same with full_size. 

A common setting in my config would be this, replacing the default width/quality settings:
`thumb_size = "x320 q50"`
`full_size = "x1060 q90"`

As I expect most people to embrace the default column-based design, I decided to not even document the extra option for now.  This is clearly for the power user only :-)