### PR TITLE
Support site custom css file

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -29,6 +29,7 @@ disableKinds = ["taxonomy", "term"]
     #images_downloadable = true
     #images_downloadable_use_orig = false
     #taxonomies_links = false
+    #custom_css = ["css/custom.css"]
 
     # Headerbar links
     # Do not put too many links here,

--- a/exampleSiteNoAlbum/config.toml
+++ b/exampleSiteNoAlbum/config.toml
@@ -29,6 +29,7 @@ disableKinds = ["taxonomy", "term"]
     #images_downloadable = true
     #images_downloadable_use_orig = false
     #taxonomies_links = false
+    #custom_css = ["css/custom.css"]
 
     # Headerbar links
     # Do not put too many links here,

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -33,3 +33,7 @@
 {{- $mg_pop_css := resources.Get "css/magnific-popup.css" -}}
 {{- $custom_css := slice $font_awesome $google_font $main_css $mg_pop_css | resources.Concat "css/custom.css" | resources.Minify | resources.Fingerprint -}}
 <link rel="stylesheet" href="{{ $custom_css.RelPermalink }}" integrity="{{ $custom_css.Data.Integrity }}"/>
+
+{{ range .Site.Params.custom_css -}}
+    <link rel="stylesheet" href="{{ . | absURL }}">
+{{- end }}


### PR DESCRIPTION
Wanting to add support for a custom css file for the site that does not live in the theme folder.
This will allow for easier customisation without affecting the ability to pull new versions from this project.