### PR TITLE
Added support for ordering albums on front page

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The `exampleSite` demonstrates the features unique to this theme.  In your site 
 * `images_downloadable` - if true, images have a download button (default true)
 * `images_downloadable_use_orig` - if true, the download button will download the original image instead of the full size image - this will likely greatly increase the size of your site (default false)
 * `taxonomies_links` - if true, links to the taxonomy pages will be present in the footer and on the tagged items (default false)
+* `sort_order` - if "newest_first", the most recent album will be displayed first with others in descending order (default "oldest_first")
 
 Additionally, `Author.name` and `Author.email` in the site config will display as the author and webmaster email.
 

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -29,6 +29,7 @@ disableKinds = ["taxonomy", "term"]
     #images_downloadable = true
     #images_downloadable_use_orig = false
     #taxonomies_links = false
+    #sort_order = "newest_first"
 
     # Headerbar links
     # Do not put too many links here,

--- a/exampleSiteNoAlbum/config.toml
+++ b/exampleSiteNoAlbum/config.toml
@@ -29,6 +29,7 @@ disableKinds = ["taxonomy", "term"]
     #images_downloadable = true
     #images_downloadable_use_orig = false
     #taxonomies_links = false
+    #sort_order = "newest_first"
 
     # Headerbar links
     # Do not put too many links here,

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -6,6 +6,7 @@
     {{- $thumb_quality := default 50 ($.Param "thumb_quality") }}
     {{- $full_quality := default 90 ($.Param "full_quality") }}
     {{- $filename_as_phototitle := default false ($.Param "filename_as_phototitle") }}
+    {{- $sort_order := default "oldest_first" ($.Param "sort_order") }}
 
     {{- /* Calculate thumb_ and full_size from params, unless one is provided in the config. */}}
     {{- $thumb_size := default (printf "%dx q%d" $thumb_width $thumb_quality) ($.Param "thumb_size") }}
@@ -14,7 +15,7 @@
 
     {{- /* Build the list of sections and thumbnails */}}
     {{- $.Scratch.Set "sections" (slice) }}
-    {{- range .Sections.ByDate }}
+    {{- range (cond (eq $sort_order "newest_first") .Sections.ByDate.Reverse .Sections.ByDate) }}
         {{- $title := .Title }}
         {{- $link := .RelPermalink }}
         {{- $weight := default 0 (.Param "weight") }}


### PR DESCRIPTION
I wanted to add the capability to order the albums on the front page based on the dates. Default is to order ByDate with the oldest first at the top which means that viewers have to scroll all the way to the bottom to get the latest albums. I wanted to provide a simple switch to reverse that order (using ByDate.Reverse) based on configuration by adding a "sort_order" to the site parameters. Default value is "oldest_first" which mirrors the current behaviour. Setting this to "newest_first" places the latest albums at the top of the page.

Also updated the README and both example sites with the configuration example commented out in the same style as the other unused configuration parameters.