### PR TITLE
Fix empty _index.md on hugo new

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ The `exampleSiteNoAlbum` directory demonstrates a no-album layout, where all pho
 
 Inside your project create the directory `assets/NAME-OF-YOUR-ALBUM`.  Place all of one album's photos inside that directory.
 
+Make sure that the theme [archetype file](https://gohugo.io/content-management/archetypes/) is used. It is responsible for the `hugo new` hook. 
+```
+$ cp themes/autophugo/archetypes/default.md archetypes/default.md
+```
+
 Inside your project run:
 
 ```


### PR DESCRIPTION
`hugo new some-dir/_index.md` was creating empty _index.md files. It was caused by an empty `archetypes/default.md` file being automatically added into new projects by hugo new site. Updated documentation to fix album construction.

fixed#38