### PR TITLE
formspree, album descriptions, empty page warning

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -14,7 +14,7 @@
 
     {{- /* Build the list of sections and thumbnails */}}
     {{- $.Scratch.Set "sections" (slice) }}
-    {{- range .Sections.ByDate }}
+    {{- range .Sections.ByDate.Reverse }}
         {{- $title := .Title }}
         {{- $link := .RelPermalink }}
         {{- $weight := default 0 (.Param "weight") }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,0 +1,1 @@
+{{ "<!-- Layout with no content to avoid WARN message about missing page layout -->" | safeHTML }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -58,7 +58,7 @@
                 <div>
                     <section>
                         <h2>{{ with .Site.Params.footer.contact.headline }}{{ . | markdownify }}{{ end }}</h2>
-                        <form method="post" action="//formspree.io/f/{{ with .Site.Params.footer.contact.formspreeID }}{{.}}{{ end }}" novalidate>
+                        <form method="post" action="{{ with .Site.Params.footer.contact.formspreeID }}{{.}}{{ end }}" novalidate>
                             <div class="field half first">
                                 <input type="text" name="name" required data-validation-required-message="{{ with .Site.Params.footer.contact.name.warning }}{{ . | markdownify}}{{ end }}" id="name" placeholder="{{ with .Site.Params.footer.contact.name.text }}{{ .  | markdownify }}{{ end }}" />
                             </div>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -4,7 +4,7 @@
             <div>
                 <section>
                     <h2>{{ with .Site.Params.footer.paragraph.headline }}{{ . | markdownify }}{{ end }}</h2>
-                    <p>{{ with .Site.Params.footer.paragraph.text }}{{ . | markdownify }}{{ end }}</p>
+                    <p>{{ with .Description }}{{ . | markdownify }}{{ end }}</p>
                 </section>
                 <section>
                     <h2>{{ with .Site.Params.footer.social.headline }}{{ . | markdownify }}{{ end }}</h2>


### PR DESCRIPTION
I should've submitted these incrementally...  Here are three changes I've made in the last few months:

- When I implemented the Contact page with Formspree, the docs said to paste the whole formspree ID, which included the https: URL prefix; I had to modify the theme to get it to work replacing the ID as a URL, thus not needing the `//formspree.io` prefix.
- Building would give me warnings about blank pages, so I added a default `single.html` but this may have been fixed with one of the recent commits already in the repo.
- I wanted each album to have it's own description so changed the `footer.html` partial template. Not everyone may like this, so perhaps its should be an option.

Feel free to change/reject any or all of these suggestions--these are what worked for my site.