### PR TITLE
Deprecation of .Site.Social

### DIFF
--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -48,7 +48,7 @@
                             {{- $thumb := $img.Resize $thumb_size }}
 
                             {{- /* Create an object representing this tag term entry */}}
-                            {{- $url := ( printf "%s/#%s" $filedir ( md5 $filename ) ) | relURL }}
+                            {{- $url := ( printf "%s/#%s" $filedir ( strings.TrimSuffix (path.Ext $filename) $filename ) ) | relURL }}
                             {{- $img_desc := dict "type" "link" "link" $url "title" $resource.phototitle "thumb" $thumb }}
                             {{- /* Add this object to the list */}}
                             {{- $cur_entry := (index ($.Scratch.Get "tags") $tag) }}

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -48,7 +48,7 @@
                             {{- $thumb := $img.Resize $thumb_size }}
 
                             {{- /* Create an object representing this tag term entry */}}
-                            {{- $url := ( printf "/%s/#%s" $filedir ( md5 $filename ) ) | relURL }}
+                            {{- $url := ( printf "%s/#%s" $filedir ( md5 $filename ) ) | relURL }}
                             {{- $img_desc := dict "type" "link" "link" $url "title" $resource.phototitle "thumb" $thumb }}
                             {{- /* Add this object to the list */}}
                             {{- $cur_entry := (index ($.Scratch.Get "tags") $tag) }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -79,6 +79,6 @@
             {{ end }}
         </div>
         <p class="copyright">
-            &copy; {{ with .Site.Params.footer.copyright.name }}{{ . | markdownify }}{{ end }}. Code generated with <a href="https://gohugo.io/">Hugo</a>, theme based on <a href="https://github.com/kc0bfv/autophugo/">AutoPhugo</a>.
+            &copy; {{ with .Site.Params.footer.copyright.name }}{{ . | markdownify }}{{ end }}. Created with <a href="https://gohugo.io/">Hugo</a> and <a href="https://github.com/kc0bfv/autophugo/">AutoPhugo</a>.
         </p>
     </footer>

--- a/layouts/partials/opengraph_twittercard.html
+++ b/layouts/partials/opengraph_twittercard.html
@@ -4,7 +4,7 @@
 <meta name="twitter:image" content="{{ (.Scratch.Get "image").Permalink }}">
 <meta name="twitter:title" content="{{ with .Title }}{{ . }} - {{ end }}{{ .Site.Title }}">
 {{- with $description }}<meta name="twitter:description" content="{{ . }}">{{ end }}
-{{- with .Site.Social.twitter }}<meta name="twitter:site" content="@{{ . }}">{{- end }}
+{{- with .Site.Params.Social.twitter }}<meta name="twitter:site" content="@{{ . }}">{{- end }}
 
 
 <meta property="og:title" content="{{ with .Title }}{{ . }} - {{ end }}{{ .Site.Title }}">
@@ -16,4 +16,4 @@
 {{- with .Site.Title }}<meta property="og:site_name" content="{{ . }}">{{ end }}
 
 {{- /* Facebook Page Admin ID for Domain Insights */}}
-{{- with .Site.Social.facebook_admin }}<meta property="fb:admins" content="{{ . }}">{{ end }}
+{{- with .Site.Params.Social.facebook_admin }}<meta property="fb:admins" content="{{ . }}">{{ end }}

--- a/layouts/partials/render_img_column_flexrow.html
+++ b/layouts/partials/render_img_column_flexrow.html
@@ -70,7 +70,7 @@
                     <a class="gallery-item" phototitle="{{ .phototitle }}"
                             {{ printf "description='%s'" (.description | markdownify) | safeHTMLAttr }}
                             gallery_index="{{ .index }}"
-                            id="{{ md5 $filename }}"
+                            id="{{ strings.TrimSuffix (path.Ext $filename) $filename }}"
                             downloadable="{{ cond $downloadable "true" "false" }}"
                             {{- if $downloadable }}
                             download_file="{{ (cond $orig_download .orig .full).RelPermalink }}"


### PR DESCRIPTION
Site.Social was deprecated in Hugo v0.124.0 and will be removed in v0.137 Using .Site.Params instead.